### PR TITLE
rename columns to podiums

### DIFF
--- a/fig-arena.svg
+++ b/fig-arena.svg
@@ -172,7 +172,7 @@
     <rect x="4.15" y="4.15" width="2.85" height="2.85" class="zone-3 line-follow-line"/>
 
     <rect width="4" height="4" x="2" y="2" class="line-follow-line"/>
-    <!-- Podiums -->
+    <!-- Columns -->
     <use xlink:href="#centre-column" x="1.85" y="3.85"/>
     <use xlink:href="#centre-column" x="3.85" y="1.85"/>
     <use xlink:href="#centre-column" x="5.85" y="3.85"/>

--- a/specs.tex
+++ b/specs.tex
@@ -48,14 +48,14 @@ is under the marker.
   \item Columns will have 4 different markers on each face, as given in
         Figure~\ref{fig:arena}.
   \item The scoring zones are squares of sides \si{3}{m} positioned with the
-        podiums separating them.
+        columns separating them.
   \item The starting and scoring zones is visually delineated on the floor of
         the arena by coloured tape. The outer edge of the tape indicates the
         outer edge of the zone. This tape is for visual reference only.
   \item \label{spec:tokenpos} Tokens will be placed in undisclosed layouts
         within an inner \si{2}{m} square of each scoring zone. The inner square
         is positioned such that two of its edges are the inside edges of the
-        scoring zones. Tokens will start at least \si{150}{mm} from podia
+        scoring zones. Tokens will start at least \si{150}{mm} from columns
         or other tokens and their layouts will be rotationally symmetric to
         that of other zones.
   \item The inner square is positioned such that two of its edges are the


### PR DESCRIPTION
Currently Columns are referred to as both podiums and columns, it should be a single name for everything.