### PR TITLE
Require movement outside the starting zone

### DIFF
--- a/game-rules.tex
+++ b/game-rules.tex
@@ -13,8 +13,8 @@
         will lose points.
   \item At the end of the game, each robot is awarded the sum of the value of
         all tokens within their scoring zone (see rule \ref{rules:token})
-  \item An additional 1 bonus point is awarded for any movement from the
-        start position of a robot.
+  \item An additional 1 bonus point is awarded if a robot moves out of its
+        starting zone.
   \item \label{rules:token}A token is in a scoring zone if, and only if, it
         has three corners in contact with the floor in the zone.
   \item Participating teams must present their robots to match officials at


### PR DESCRIPTION
This makes judging this point _much_ easier as we no longer need to remember the actual starting position of the robot.