### PR TITLE
Drop the 'printable' PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 rules.pdf
-rules_printable.pdf
 rules.aux
 rules.log
 rules.out

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ COMPILESVG=inkscape
 
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
-rules_printable.pdf: rules.pdf
-	convert -density 300 $< $@
-
 rules.pdf: rules.tex specs.tex game-rules.tex regulations.tex fig-sidewall.pdf \
            fig-arena.pdf fig-sourcebots.pdf
 	pdflatex $(PDFLATEXFLAGS) $<


### PR DESCRIPTION
This version of the file takes ages to render and ends up being 100 times as large (8.7M vs 79k) as the original without offering any actual simplification in the resulting graphics.