### PR TITLE
Add a specification for robot flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPILESVG=inkscape
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
 rules.pdf: rules.tex specs.tex game-rules.tex regulations.tex fig-sidewall.pdf \
-           fig-arena.pdf fig-sourcebots.pdf
+           fig-arena.pdf fig-sourcebots.pdf fig-flag.pdf
 	pdflatex $(PDFLATEXFLAGS) $<
 	pdflatex $(PDFLATEXFLAGS) $<
 

--- a/fig-flag.svg
+++ b/fig-flag.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="350mm"
+   height="550mm"
+   viewBox="0 0 350 550"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="flag.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.42763516"
+     inkscape:cx="114.04281"
+     inkscape:cy="1281.2358"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1440"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,253)">
+    <rect
+       style="opacity:1;vector-effect:none;fill:#999999;fill-opacity:1;stroke:#000000;stroke-width:1.89906228;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect821"
+       width="18.100937"
+       height="498.10095"
+       x="130.31882"
+       y="-248.22775" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.96619296;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect823"
+       width="198.03381"
+       height="98.033806"
+       x="148.41975"
+       y="-248.22775" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.00403953;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 126.15546,-248.18812 h -15.11799 v 496.10167 h 16.93215"
+       id="path825"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458302px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="26.01836"
+       y="-10.036629"
+       id="text829"><tspan
+         sodipodi:role="line"
+         id="tspan827"
+         x="26.01836"
+         y="-10.036629"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">&gt;50cm</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 130.05941,253.60023 v 9.00991 h 18.36035 v -10.0911"
+       id="path825-3-3"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="111.28967"
+       y="287.57559"
+       id="text829-67"><tspan
+         sodipodi:role="line"
+         id="tspan827-5"
+         x="111.28967"
+         y="287.57559"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">&lt;1cm</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 152.64021,-145.14494 v 14.59185 h 192.40492 v -16.34287"
+       id="path825-3-35"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="219.86436"
+       y="-106.569"
+       id="text829-6-6"><tspan
+         sodipodi:role="line"
+         id="tspan827-7-2"
+         x="219.86436"
+         y="-106.569"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">20cm</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 154.99644,251.07011 h 13.89259 V -146.6781 h -15.5597"
+       id="path825-3-9"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="181.94379"
+       y="50.795963"
+       id="text829-6-1"><tspan
+         sodipodi:role="line"
+         id="tspan827-7-27"
+         x="181.94379"
+         y="50.795963"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">40cm</tspan></text>
+  </g>
+</svg>

--- a/fig-flag.svg
+++ b/fig-flag.svg
@@ -14,8 +14,8 @@
    viewBox="0 0 350 550"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
-   sodipodi:docname="flag.svg">
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   sodipodi:docname="fig-flag.svg">
   <defs
      id="defs2" />
   <sodipodi:namedview
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.42763516"
-     inkscape:cx="114.04281"
-     inkscape:cy="1281.2358"
+     inkscape:zoom="0.44541644"
+     inkscape:cx="707.22861"
+     inkscape:cy="1122.0225"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -57,36 +57,36 @@
     <rect
        style="opacity:1;vector-effect:none;fill:#999999;fill-opacity:1;stroke:#000000;stroke-width:1.89906228;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect821"
-       width="18.100937"
+       width="14.767598"
        height="498.10095"
-       x="130.31882"
+       x="133.49377"
        y="-248.22775" />
     <rect
        style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.96619296;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect823"
-       width="198.03381"
-       height="98.033806"
-       x="148.41975"
+       width="164.03381"
+       height="109.03381"
+       x="148.26137"
        y="-248.22775" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.00403953;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 126.15546,-248.18812 h -15.11799 v 496.10167 h 16.93215"
+       d="m 128.80131,-248.18812 h -15.11799 v 496.10167 h 16.93215"
        id="path825"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458302px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="26.01836"
+       x="33.212986"
        y="-10.036629"
        id="text829"><tspan
          sodipodi:role="line"
          id="tspan827"
-         x="26.01836"
+         x="33.212986"
          y="-10.036629"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">&gt;50cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">45cm</tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 130.05941,253.60023 v 9.00991 h 18.36035 v -10.0911"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 133.18527,253.60023 v 9.00991 h 15.23449 v -10.0911"
        id="path825-3-3"
        inkscape:connector-curvature="0" />
     <text
@@ -99,38 +99,38 @@
          id="tspan827-5"
          x="111.28967"
          y="287.57559"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">&lt;1cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">1.5cm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 152.64021,-145.14494 v 14.59185 h 192.40492 v -16.34287"
+       d="m 151.29957,-135.48975 v 14.59185 h 161.1568 v -16.34287"
        id="path825-3-35"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="219.86436"
-       y="-106.569"
+       x="203.98553"
+       y="-98.70845"
        id="text829-6-6"><tspan
          sodipodi:role="line"
          id="tspan827-7-2"
-         x="219.86436"
-         y="-106.569"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">20cm</tspan></text>
+         x="203.98553"
+         y="-98.70845"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">15cm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 154.99644,251.07011 h 13.89259 V -146.6781 h -15.5597"
+       d="m 154.99644,251.07028 h 13.89259 v -386.46229 h -15.5597"
        id="path825-3-9"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="181.94379"
-       y="50.795963"
+       x="177.78569"
+       y="53.766029"
        id="text829-6-1"><tspan
          sodipodi:role="line"
          id="tspan827-7-27"
-         x="181.94379"
-         y="50.795963"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">40cm</tspan></text>
+         x="177.78569"
+         y="53.766029"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">35cm</tspan></text>
   </g>
 </svg>

--- a/fig-flag.svg
+++ b/fig-flag.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="350mm"
-   height="550mm"
-   viewBox="0 0 350 550"
+   width="507.20981mm"
+   height="537.06616mm"
+   viewBox="0 0 507.20981 537.06616"
    version="1.1"
    id="svg8"
    inkscape:version="0.92.2 2405546, 2018-03-11"
@@ -25,18 +25,22 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.44541644"
-     inkscape:cx="707.22861"
-     inkscape:cy="1122.0225"
+     inkscape:zoom="0.39922561"
+     inkscape:cx="832.34916"
+     inkscape:cy="1189.4625"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
      showguides="false"
-     inkscape:window-width="2560"
-     inkscape:window-height="1440"
+     inkscape:window-width="1276"
+     inkscape:window-height="1313"
      inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0" />
+     inkscape:window-y="95"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -45,7 +49,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,20 +57,20 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,253)">
+     transform="translate(-34.775681,249.21085)">
     <rect
-       style="opacity:1;vector-effect:none;fill:#999999;fill-opacity:1;stroke:#000000;stroke-width:1.89906228;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;vector-effect:none;fill:#999999;fill-opacity:1;stroke:#000000;stroke-width:1.8990624;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect821"
-       width="14.767598"
+       width="35.600937"
        height="498.10095"
        x="133.49377"
        y="-248.22775" />
     <rect
-       style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.96619296;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.9661932;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect823"
-       width="164.03381"
-       height="109.03381"
-       x="148.26137"
+       width="373.03381"
+       height="248.0338"
+       x="169.09471"
        y="-248.22775" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.00403953;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -83,54 +87,54 @@
          id="tspan827"
          x="33.212986"
          y="-10.036629"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">45cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">20cm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 133.18527,253.60023 v 9.00991 h 15.23449 v -10.0911"
+       d="m 133.5651,253.60023 v 9.00991 h 35.86069 v -10.0911"
        id="path825-3-3"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="111.28967"
-       y="287.57559"
+       x="119.77333"
+       y="285.98489"
        id="text829-67"><tspan
          sodipodi:role="line"
          id="tspan827-5"
-         x="111.28967"
-         y="287.57559"
+         x="119.77333"
+         y="285.98489"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">1.5cm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 151.29957,-135.48975 v 14.59185 h 161.1568 v -16.34287"
+       d="M 176.451,5.6166497 V 20.2085 H 539.73393 V 3.8656297"
        id="path825-3-35"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="203.98553"
-       y="-98.70845"
+       x="318.22998"
+       y="42.397949"
        id="text829-6-6"><tspan
          sodipodi:role="line"
          id="tspan827-7-2"
-         x="203.98553"
-         y="-98.70845"
+         x="318.22998"
+         y="42.397949"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">15cm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 154.99644,251.07028 h 13.89259 v -386.46229 h -15.5597"
+       d="m 177.75075,251.18219 h 13.89259 V 5.6166497 h -15.5597"
        id="path825-3-9"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458349px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="177.78569"
-       y="53.766029"
+       x="205.5058"
+       y="147.00641"
        id="text829-6-1"><tspan
          sodipodi:role="line"
-         id="tspan827-7-27"
-         x="177.78569"
-         y="53.766029"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">35cm</tspan></text>
+         x="205.5058"
+         y="147.00641"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px"
+         id="tspan826">10cm</tspan></text>
   </g>
 </svg>

--- a/fig-flag.svg
+++ b/fig-flag.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="507.20981mm"
-   height="537.06616mm"
-   viewBox="0 0 507.20981 537.06616"
+   width="520.50677mm"
+   height="535.47546mm"
+   viewBox="0 0 520.50678 535.47546"
    version="1.1"
    id="svg8"
    inkscape:version="0.92.2 2405546, 2018-03-11"
@@ -25,17 +25,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.39922561"
-     inkscape:cx="832.34916"
-     inkscape:cy="1189.4625"
+     inkscape:zoom="0.48226766"
+     inkscape:cx="1669.0691"
+     inkscape:cy="1223.3209"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
      showguides="false"
-     inkscape:window-width="1276"
-     inkscape:window-height="1313"
+     inkscape:window-width="2560"
+     inkscape:window-height="1440"
      inkscape:window-x="0"
-     inkscape:window-y="95"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -57,7 +57,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-34.775681,249.21085)">
+     transform="translate(-22.604836,249.21085)">
     <rect
        style="opacity:1;vector-effect:none;fill:#999999;fill-opacity:1;stroke:#000000;stroke-width:1.8990624;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect821"
@@ -80,14 +80,14 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.58333302px;line-height:6.61458302px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="33.212986"
+       x="21.042141"
        y="-10.036629"
        id="text829"><tspan
          sodipodi:role="line"
          id="tspan827"
-         x="33.212986"
+         x="21.042141"
          y="-10.036629"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">20cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">200mm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 133.5651,253.60023 v 9.00991 h 35.86069 v -10.0911"
@@ -103,7 +103,7 @@
          id="tspan827-5"
          x="119.77333"
          y="285.98489"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">1.5cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">15mm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 176.451,5.6166497 V 20.2085 H 539.73393 V 3.8656297"
@@ -119,7 +119,7 @@
          id="tspan827-7-2"
          x="318.22998"
          y="42.397949"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">15cm</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px">150mm</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 177.75075,251.18219 h 13.89259 V 5.6166497 h -15.5597"
@@ -135,6 +135,6 @@
          x="205.5058"
          y="147.00641"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.75555611px;font-family:Sans-serif;-inkscape-font-specification:'Sans-serif Bold';stroke-width:0.26458332px"
-         id="tspan826">10cm</tspan></text>
+         id="tspan826">100mm</tspan></text>
   </g>
 </svg>

--- a/regulations.tex
+++ b/regulations.tex
@@ -45,8 +45,8 @@
      individually approved by \org before use.
 \item A robot's main power switch must be easily accessible and on the top of
       the robot whenever the robot is powered.
-%\item All robots must have badge mountings as described in
-%      \specref{spec:badges}.
+\item All robots must have robot identifying flag mountings for flags described in
+      \specref{spec:flags}.
 \item All electronics on a robot must be:
   \begin{enumerate}
     \item securely held in place;

--- a/regulations.tex
+++ b/regulations.tex
@@ -45,8 +45,9 @@
      individually approved by \org before use.
 \item A robot's main power switch must be easily accessible and on the top of
       the robot whenever the robot is powered.
-\item All robots must have robot identifying flag mountings for flags described in
-      \specref{spec:flags}.
+\item All robots must have mountings for the provided removable identifying flags,
+      as described in \specref{spec:flags}. A mounting must firmly hold a flag
+      in an upright position.
 \item All electronics on a robot must be:
   \begin{enumerate}
     \item securely held in place;

--- a/regulations.tex
+++ b/regulations.tex
@@ -47,7 +47,8 @@
       the robot whenever the robot is powered.
 \item All robots must have mountings for the removable identifying flags
       provided by \org, as described in \specref{spec:flags}. A mounting
-      must firmly hold a flag in an upright position.
+      must firmly hold a flag in an upright position. Flags are not counted
+      when considering the starting size of the robot.
 \item All electronics on a robot must be:
   \begin{enumerate}
     \item securely held in place;

--- a/regulations.tex
+++ b/regulations.tex
@@ -45,9 +45,9 @@
      individually approved by \org before use.
 \item A robot's main power switch must be easily accessible and on the top of
       the robot whenever the robot is powered.
-\item All robots must have mountings for the provided removable identifying flags,
-      as described in \specref{spec:flags}. A mounting must firmly hold a flag
-      in an upright position.
+\item All robots must have mountings for the removable identifying flags
+      provided by \org, as described in \specref{spec:flags}. A mounting
+      must firmly hold a flag in an upright position.
 \item All electronics on a robot must be:
   \begin{enumerate}
     \item securely held in place;

--- a/rules.tex
+++ b/rules.tex
@@ -74,6 +74,8 @@ Since first publication, this document has had the following changes made:
         \item The marker numbers used on tokens have been changed so that each
               robot has a consistent number of markers. The API and example
               markers in the docs were already correct and have not changed.
+        \item Robots are now required to have a mount for flags solidly attached.
+              Flags will be provided by \org.
     \end{itemize}
 \end{itemize}
 

--- a/specs.tex
+++ b/specs.tex
@@ -66,10 +66,10 @@ is under the marker.
         that of other zones.
   \item Tokens will be placed in the scoring zone on the opposite side to their
         matching coloured scoring zone.
-  \item \label{spec:flags} Flags will be made from wire folded in half
-        to form a single rod with a maximum width of less than \si{10}{mm},
-        and length of more than \si{500}{mm}. The length of rod without
-        a flag will be \si{400}{mm}, as described in \figref{fig:flag}.
+  \item \label{spec:flags} Flags will be made from PVC Piping with a diameter
+        of \si{15}{mm}, and a length of \si{45}{mm} or longer. There will be
+        a flag attached \si{350}{mm} from the top, with a height of \si{100}{mm}
+        and a width of \si{150}{mm}, as described in \figref{fig:flag}.
 
 \end{enumerate}
 

--- a/specs.tex
+++ b/specs.tex
@@ -66,6 +66,11 @@ is under the marker.
         that of other zones.
   \item Tokens will be placed in the scoring zone on the opposite side to their
         matching coloured scoring zone.
+  \item \label{spec:flags} Flags will be made from wire folded in half
+        to form a single rod with a maximum width of less than \si{10}{mm},
+        and length of more than \si{500}{mm}. The length of rod without
+        a flag will be \si{400}{mm}, as described in \figref{fig:flag}.
+
 \end{enumerate}
 
 \begin{sidewaysfigure}
@@ -82,6 +87,11 @@ is under the marker.
   \label{fig:arena}
 \end{figure}
 
+\begin{figure}
+  \includegraphics[scale=0.3]{fig-flag.pdf}
+  \caption{Specification of a robot flag}
+  \label{fig:flag}
+\end{figure}
 \subsection{Tokens}
 \refstepcounter{SpecID}
 \label{spec:tokens}

--- a/specs.tex
+++ b/specs.tex
@@ -53,7 +53,7 @@ is under the marker.
         \figref{fig:arena}.
   \item Markers will be placed on columns such that there is a \SI{120}{mm} 
         gap at the bottom.
-  \item The scoring zones are squares of sides \si{2815}{mm}$\pm$\SI{50}{mm}
+  \item The scoring zones are squares with sides \si{2815}{mm}$\pm$\SI{50}{mm}
         positioned with the columns separating them.
   \item The starting and scoring zones is visually delineated on the floor of
         the arena by coloured tape. The outer edge of the tape indicates the

--- a/specs.tex
+++ b/specs.tex
@@ -66,7 +66,7 @@ is under the marker.
         that of other zones.
   \item Tokens will be placed in the scoring zone on the opposite side to their
         matching coloured scoring zone.
-  \item \label{spec:flags} Flags will be made from PVC Piping with a diameter
+  \item \label{spec:flags} Flags will be cylinders with a diameter
         of \si{15}{mm}, and a length of \si{200}{mm} or longer. There will be
         a decoration attached \si{100}{mm} from the top, with a height of \si{100}{mm}
         and a width of \si{150}{mm}, as described in \figref{fig:flag}. The

--- a/specs.tex
+++ b/specs.tex
@@ -69,7 +69,8 @@ is under the marker.
   \item \label{spec:flags} Flags will be made from PVC Piping with a diameter
         of \si{15}{mm}, and a length of \si{200}{mm} or longer. There will be
         a decoration attached \si{100}{mm} from the top, with a height of \si{100}{mm}
-        and a width of \si{150}{mm}, as described in \figref{fig:flag}.
+        and a width of \si{150}{mm}, as described in \figref{fig:flag}. The
+        cloth part of the flag must be visible when attached to the mount.
 
 \end{enumerate}
 

--- a/specs.tex
+++ b/specs.tex
@@ -67,8 +67,8 @@ is under the marker.
   \item Tokens will be placed in the scoring zone on the opposite side to their
         matching coloured scoring zone.
   \item \label{spec:flags} Flags will be made from PVC Piping with a diameter
-        of \si{15}{mm}, and a length of \si{45}{mm} or longer. There will be
-        a flag attached \si{350}{mm} from the top, with a height of \si{100}{mm}
+        of \si{15}{mm}, and a length of \si{200}{mm} or longer. There will be
+        a decoration attached \si{100}{mm} from the top, with a height of \si{100}{mm}
         and a width of \si{150}{mm}, as described in \figref{fig:flag}.
 
 \end{enumerate}


### PR DESCRIPTION
We decided we don't want robot badges this year, but we still
want robots to have their corner identifiable, so we decided
robots should have a flag mount.

The reasoning for flags instead of badges is they require a smaller footprint and can be retro-fit to a robot more-so than badges. Now that it's 2 weeks before the competition, flags are more likely to be put onto a robot.