### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         working_directory: ~/sb2018-rules
         steps:
             - checkout
-            - run: make COMPILESVG=svg2pdf
+            - run: make
             - store_artifacts:
                 path: rules.pdf
                 destination: rules.pdf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: theorangeone/docker-pandoc
+        working_directory: ~/sb2018-rules
+        steps:
+            - checkout
+            - run: make COMPILESVG=svg2pdf
+            - store_artifacts:
+                path: rules.pdf
+                destination: rules.pdf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 SourceBots 2018 Rules
 ================
 
+[![CircleCI](https://circleci.com/gh/sourcebots/sb2018-rules.svg?style=svg)](https://circleci.com/gh/sourcebots/sb2018-rules)
+
 The rulebook for SourceBots 2018


### PR DESCRIPTION
Use CircleCI to build the the PDF and store as artifact. 

Uses https://github.com/RealOrangeOne/docker-pandoc, same implementation as https://github.com/sourcebots/media-consent/pull/2